### PR TITLE
chore: pin official actions as well

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,8 +7,7 @@
   "packageRules": [
     {
       "matchDepTypes": ["action"],
-      "pinDigests": true,
-      "matchPackageNames": ["!actions/{/,}**", "!github/{/,}**"]
+      "pinDigests": true
     }
   ],
   "ignoreDeps": [


### PR DESCRIPTION
so that we can enable ["enforce SHA pinning"](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/#enforce-sha-pinning) setting across the org